### PR TITLE
Fix bug Undefined variable _SESSION

### DIFF
--- a/PDW/views/panels/request.phtml
+++ b/PDW/views/panels/request.phtml
@@ -13,6 +13,7 @@
 			</thead>
 			<tbody>
 			<?php
+            if(isset($_SESSION)){
 				foreach($_SESSION as $k=>$v):
 					$class = is_array($v)? "language-php" : "";
 					echo "<tr>";
@@ -22,6 +23,7 @@
 						echo "</code></pre></td>";
 					echo "</tr>";
 				endforeach;
+            }
 			?>
 			</tbody>
 		</table>

--- a/PDW/views/toolbar/index.phtml
+++ b/PDW/views/toolbar/index.phtml
@@ -54,8 +54,12 @@
 					<td><?php echo number_format(memory_get_peak_usage()/1024, 2); ?> KB</td>
 				</tr>
 				<tr>
-					<td>session size</td>
-					<td><?php printf('%0.3F KB' ,mb_strlen(serialize($_SESSION))/1024); ?></td>
+                   <td>session size</td>
+                    <?php if(isset($_SESSION)):?>
+					    <td><?php printf('%0.3F KB' ,mb_strlen(serialize($_SESSION))/1024); ?></td>
+                    <?php else:?>
+                        <td>0</td>
+                    <?php endif?>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
if use pdw without session_start it will cause php error, add isset($_SESSION) check in toolbar and request.phtml.
