### PR TITLE
Fix info output

### DIFF
--- a/PDW/views/panels/db.phtml
+++ b/PDW/views/panels/db.phtml
@@ -51,7 +51,10 @@
 				foreach($descriptors as $k=>$v):
 					echo "<tr>";
 						echo "<td>{$k}</td>";
-						echo "<td>{$v}</td>";
+						if (is_string($v)) {
+							echo "<td>{$v}</td>";
+						}
+						echo "<td>&nbsp;</td>";
 					echo "</tr>";
 				endforeach;
 			?>


### PR DESCRIPTION
How to reproduce error:

_services.php_

``` php
<?php

$di->set('db', function() use($config, $di){
    $connection = new \Phalcon\Db\Adapter\Pdo\Mysql($config->database->toArray());
    return $connection;
});
```

_config.php_

``` php
<?php

return new \Phalcon\Config([
    'database' => [
        'adapter'  => 'Mysql',
        'host'     => 'localhost',
        'username' => 'dbuser',
        'password' => 'dbpass',
        'dbname'   => 'dbname',
        'options'  => [
            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'UTF8'",
            PDO::ATTR_CASE               => PDO::CASE_LOWER
        ]
    ]
]);
```
